### PR TITLE
fix:#32 user password설정변경

### DIFF
--- a/migrations/20250508055242-addUserPassword.cjs
+++ b/migrations/20250508055242-addUserPassword.cjs
@@ -4,7 +4,7 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.addColumn("users", "password", {
       type: Sequelize.STRING,
-      allowNull: false,
+      allowNull: true,
       // unique: true,  // 비밀번호는 중복 가능
     });
   },

--- a/migrations/20250510143642-addjwtTokenTable.cjs
+++ b/migrations/20250510143642-addjwtTokenTable.cjs
@@ -32,6 +32,7 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint("jwtToken", "jwttoken_ibfk_1");
     await queryInterface.removeIndex("jwtToken", "jwt_token_users_user_id_fk");
     await queryInterface.dropTable("jwtToken");
   },

--- a/models/database/Users.js
+++ b/models/database/Users.js
@@ -19,6 +19,10 @@ export default class Users extends Model {
       type: DataTypes.STRING(255),
       allowNull: true
     },
+    password: {
+      type: DataTypes.STRING(255),
+      allowNull: true, // 소셜 로그인 사용자를 위해 null 허용
+    },
     birth: {
       type: DataTypes.DATE,
       allowNull: true
@@ -67,7 +71,7 @@ export default class Users extends Model {
     email: {
       type: DataTypes.STRING(255),
       allowNull: true
-    }
+    },
   }, {
     sequelize,
     tableName: 'users',

--- a/src/repositories/socialLogin/socialLogin.repository.js
+++ b/src/repositories/socialLogin/socialLogin.repository.js
@@ -7,13 +7,14 @@ export default class SocialLoginRepository {
     return await db.Users.findOne({ where: { kakao_id: kakaoId } });
   }
 
-  async createUser({ kakaoId, email, nickname, name, gender, birth, status }) {
+  async createUser({ kakaoId, email, nickname, name, gender, birth, status, password }) {
     return await db.Users.create({
       kakaoId: kakaoId,
       email: email,
       nickname: nickname,
       name,
       gender,
+      password: '',
       birth,
       status,
       created_at: new Date(),

--- a/src/services/socialLogin/socialLogin.service.js
+++ b/src/services/socialLogin/socialLogin.service.js
@@ -57,6 +57,7 @@ export default class SocialLoginService {
           name,
           gender,
           birth,
+          password: '',
           status: 'active',
         }
       );


### PR DESCRIPTION
## #️⃣연관된 이슈

> 소셜로그인, 로그인

## 📝작업 내용

> 소셜로그인 시 비밀번호를 받을 수 없어서 allownull : true로 바꿨습니다.
> migration undo할 때 제약조건이 지워지지 않아서 실행되지 않았던 부분 고쳤습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
