### PR TITLE
Refactor/#35 search api error handling

### DIFF
--- a/src/controllers/maps/place.controller.js
+++ b/src/controllers/maps/place.controller.js
@@ -1,35 +1,22 @@
-// src/controllers/maps/place.controller.js
 import { searchPlacesFromTmap } from '../../services/maps/place.service.js';
+import { InvalidInputError } from '../../utils/errors/errors.js';
+import { OkSuccess } from '../../utils/success/success.js';
 
-export const searchPlaces = async (req, res) => {
+export const searchPlaces = async (req, res, next) => {
   try {
     const query = req.query.query;
 
     if (!query) {
-      return res.status(400).json({
-        isSuccess: false,
-        code: 'COMMON400',
-        message: '검색어(query)는 필수입니다.',
-        result: null,
-      });
-    }
+      throw new InvalidInputError('검색어(query)는 필수입니다.');
+    }// 검색어 입력 안했을 때 에러 처리 
 
     const result = await searchPlacesFromTmap(query);
-    //console.log('🔍 요청 query:', req.query.query);  // <- 이거 추가!
 
+    // console.log('🔍 요청 query:', query); 로그 찍을 때 사용 
 
-    res.status(200).json({
-      isSuccess: true,
-      code: 'COMMON200',
-      message: '성공입니다.',
-      result,
-    });
+    return res.status(200).json(new OkSuccess(result));
   } catch (error) {
-    res.status(500).json({
-      isSuccess: false,
-      code: 'COMMON500',
-      message: '서버 오류입니다.',
-      result: error.message,
-    });
+    console.error('❌ [Tmap 장소 검색 실패]', error.message);
+    next(error); 
   }
 };

--- a/src/controllers/route/route.controller.js
+++ b/src/controllers/route/route.controller.js
@@ -1,19 +1,15 @@
-// src/controllers/route/route.controller.js
 import { getWalkingRouteByPlaceNames } from '../../services/route/route.service.js';
+import { InvalidInputError } from '../../utils/errors/errors.js';
+import { OkSuccess } from '../../utils/success/success.js';
 
-export const getWalkingRoute = async (req, res) => {
+export const getWalkingRoute = async (req, res, next) => {
   try {
     const { originName, destinationName } = req.query;
     let waypointNames = req.query.waypointName;
 
     if (!originName || !destinationName) {
-      return res.status(400).json({
-        isSuccess: false,
-        code: 'COMMON400',
-        message: '잘못된 요청입니다.',
-        result: '출발지(originName)와 목적지(destinationName)는 필수입니다.',
-      });
-    }
+      throw new InvalidInputError('출발지(originName)와 목적지(destinationName)는 필수입니다.');
+    }//출발지랑 목적지가 같지 않을 때 에러 처리 
 
     if (typeof waypointNames === 'string') {
       waypointNames = [waypointNames];
@@ -22,41 +18,9 @@ export const getWalkingRoute = async (req, res) => {
     const result = await getWalkingRouteByPlaceNames(originName, destinationName, waypointNames);
 
     console.log('✅ [Tmap 경로 응답 성공]');
-    
-    res.status(200).json({
-      isSuccess: true,
-      code: 'COMMON200',
-      message: '성공입니다.',
-      result,
-    });
+    return res.status(200).json(new OkSuccess(result));
   } catch (error) {
     console.error('❌ [Tmap 경로 요청 실패]', error.message);
-    const knownMessages = {
-      NOT_FOUND: {
-        message: '잘못된 요청입니다.',
-        result: '출발지와 목적지 형식이 잘못되었습니다.',
-      },
-      SAME_LOCATION: {
-        message: '잘못된 요청입니다.',
-        result: '출발지와 목적지가 동일할 수 없습니다.',
-      },
-    };
-
-    const type = error.code;
-    if (knownMessages[type]) {
-      return res.status(400).json({
-        isSuccess: false,
-        code: 'COMMON400',
-        message: knownMessages[type].message,
-        result: knownMessages[type].result,
-      });
-    }
-
-    res.status(500).json({
-      isSuccess: false,
-      code: 'COMMON500',
-      message: '서버 오류입니다.',
-      result: error.message,
-    });
+    next(error); 
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use("/api/auth", authRoutes); // auth 라우터 등록
 app.use('/api', placeRouter); // 장소검색 라우터 등록
- app.use('/api', routeRouter);//경로검색 라우터 등록 
+app.use('/api', routeRouter);//경로검색 라우터 등록 
 app.use("/api", locationRouter);
 app.use("/api/auth", authRoutes);
 

--- a/src/services/route/route.service.js
+++ b/src/services/route/route.service.js
@@ -3,21 +3,26 @@ import axios from 'axios';
 import { searchPlacesFromTmap } from '../maps/place.service.js';
 import { RouteResponseDto } from '../../dtos/route/response/routeResponse.dto.js';
 import { TMAP_API_KEY } from '../../../config/tmap.config.js';
+import {
+  NotExistsError,
+  InvalidInputError,
+  SampleError,
+} from '../../utils/errors/errors.js';
+
 
 const getFirstPlaceCoord = async (placeName) => {
   const places = await searchPlacesFromTmap(placeName);
   if (!places.length) {
-    const error = new Error(`장소명을 찾을 수 없습니다: ${placeName}`);
-    error.code = 'NOT_FOUND';
-    throw error;
+    throw new NotExistsError(`장소명을 찾을 수 없습니다: ${placeName}`);
   }
   return {
     lat: places[0].lat,
     lng: places[0].lng,
   };
-};
+};//좌표값 찾는 함수 
 
 export const getWalkingRouteByPlaceNames = async (originName, destinationName, waypointNames = []) => {
+  try{
   console.log('[경로 검색 요청]');
   console.log('originName:', originName);
   console.log('destinationName:', destinationName);
@@ -33,9 +38,7 @@ export const getWalkingRouteByPlaceNames = async (originName, destinationName, w
   console.log('waypoints:', waypoints);
 
   if (origin.lat === destination.lat && origin.lng === destination.lng) {
-    const error = new Error('출발지와 목적지가 동일합니다.');
-    error.code = 'SAME_LOCATION';
-    throw error;
+      throw new InvalidInputError('출발지와 목적지가 동일할 수 없습니다.');
   }
 
   let passList = waypoints
@@ -75,4 +78,11 @@ export const getWalkingRouteByPlaceNames = async (originName, destinationName, w
 
   const nameSummary = [originName, ...waypointNames, destinationName].join(' → ');
   return new RouteResponseDto(response.data, nameSummary);
+
+}catch (error) {
+    if (error.response?.status === 400) {
+      throw new InvalidInputError('Tmap에서 경로를 생성할 수 없습니다. 경유지를 확인해주세요.', error.response?.data);
+    }
+    throw new SampleError('Tmap 요청 중 서버에러가 발생했습니다.', error.message);
+  }
 };

--- a/src/utils/errors/errors.js
+++ b/src/utils/errors/errors.js
@@ -1,7 +1,7 @@
 /**
  * 상속받아 사용하는 에러 클래스
  */
-class CustomError extends Error {
+export class CustomError extends Error {
   constructor(reason, errorCode, statusCode, data = null) {
     super(reason); // error.message = reason
     this.reason = reason; // error.reason = reason
@@ -12,11 +12,10 @@ class CustomError extends Error {
     Error.captureStackTrace(this, this.constructor);
   }
 }
-
 /**
  * 에러 추가 예시 500
  */
-class SampleError extends CustomError {
+export class SampleError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "SAMPLE_ERROR", 500, data);
   }
@@ -25,7 +24,7 @@ class SampleError extends CustomError {
 /**
  * 사용자가 입력값 잘 못 넣은 경우 400
  */
-class InvalidInputError extends CustomError {
+export class InvalidInputError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "INVALID_INPUT", 400, data);
   }
@@ -34,7 +33,7 @@ class InvalidInputError extends CustomError {
 /**
  * 요청한게 이미 존재하는 경우 409
  */
-class AlreadyExistsError extends CustomError {
+export class AlreadyExistsError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "ALREADY_EXISTS", 409, data);
   }
@@ -43,7 +42,7 @@ class AlreadyExistsError extends CustomError {
 /**
  * 요청한게 존재하지 않는 경우 404
  */
-class NotExistsError extends CustomError {
+export class NotExistsError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "NOT_EXISTS", 404, data);
   }
@@ -52,7 +51,7 @@ class NotExistsError extends CustomError {
 /**
  * 인증은 되었으나 권한이 부족한 경우 403
  */
-class NotAllowedError extends CustomError {
+export class NotAllowedError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "NOT_ALLOWED", 403, data);
   }
@@ -61,7 +60,7 @@ class NotAllowedError extends CustomError {
 /**
  * 인증 정보가 제공되어 있지 않은 경우 401
  */
-class UnauthorizedError extends CustomError {
+export class UnauthorizedError extends CustomError {
   constructor(reason, data = null) {
     super(reason, "UNAUTHORIZED", 401, data);
   }
@@ -75,14 +74,3 @@ class UnauthorizedError extends CustomError {
 //     super(reason, "UNKNOWN_ERROR", 500, data);
 //   }
 // }
-
-module.exports = {
-  CustomError,
-  SampleError,
-  InvalidInputError,
-  AlreadyExistsError,
-  NotExistsError,
-  NotAllowedError,
-  UnauthorizedError,
-  // UnknownError,
-};

--- a/src/utils/success/success.js
+++ b/src/utils/success/success.js
@@ -1,4 +1,4 @@
-class SuccessResponse {
+export class SuccessResponse {
   constructor(result = null, code = "COMMON200", message = "성공입니다.") {
     this.isSuccess = true;
     this.code = code;
@@ -7,26 +7,21 @@ class SuccessResponse {
   }
 }
 
-class OkSuccess extends SuccessResponse {
+export class OkSuccess extends SuccessResponse {
   constructor(result = null, message = "성공입니다.") {
     super(result, "COMMON200", message);
   }
 }
 
-class CreatedSuccess extends SuccessResponse {
+export class CreatedSuccess extends SuccessResponse {
   constructor(result = null, message = "생성이 완료되었습니다.") {
     super(result, "COMMON201", message);
   }
 }
 
-class NoContentSuccess extends SuccessResponse {
+export class NoContentSuccess extends SuccessResponse {
   constructor() {
     super(null, "COMMON204", "내용이 없습니다.");
   }
 }
 
-module.exports = {
-  OkSuccess,
-  CreatedSuccess,
-  NoContentSuccess,
-};


### PR DESCRIPTION
## #️⃣연관된 이슈

#35 

## 📝작업 내용

**장소 검색  컨트롤러 리팩토링**
  - query 미입력 시 InvalidInputError throw
  - 공통 성공 응답 클래스 `OkSuccess` 사용
  - 에러는 `next(error)`로 넘기고, 에러 핸들러에서 처리

**경로 조회(`GET /api/maps`) 컨트롤러 리팩토링**
  - 출발지/도착지 누락 시 InvalidInputError throw
  - 공통 성공 응답 `OkSuccess` 적용
  - catch 블록 제거하고 `next(error)`만 호출하도록 리팩토링

**기타 변경**
- `errors.js`는 CommonJS 방식이라 import 시 경로/형식 일치 확인 필요 -> esm 방식으로 수정 


