### PR TITLE
fix:#43 social-to-jwt

### DIFF
--- a/src/services/socialLogin/socialLogin.service.js
+++ b/src/services/socialLogin/socialLogin.service.js
@@ -39,14 +39,14 @@ export default class SocialLoginService {
       await this.repo.updateLastLogin(user.userId);
     }
 
+    const token = jwt.sign({ userId: user.userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+
     await this.repo.saveSocialLogin(new SocialLoginDto({
       userId: user.userId,
-      accessToken,
+      accessToken: token,
       email,
       platform: 'kakao',
     }));
-
-    const token = jwt.sign({ userId: user.userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
 
     return { token };
   }
@@ -79,15 +79,16 @@ export default class SocialLoginService {
       await this.repo.updateLastLogin(user.userId);
     }
 
+    const token = jwt.sign({ userId: user.userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+
     await this.repo.saveSocialLogin(new SocialLoginDto({
       userId: user.userId,
-      accessToken: access_token,
+      accessToken: token,
       email,
       platform: 'google',
     }));
 
-    const token = jwt.sign({ userId: user.userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
-
+    
     return { token };
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43 

## 📝작업 내용

> 소셜로그인 테이블에 기존에는 카카오, 구글에서 발급해준 토큰이 저장되어있었는데 경로생성과정에서 jwt토큰이 필요하기 때문에 이 토큰을 저장하는 형식으로 바꿨습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
