### PR TITLE
♻️ refacter: 루트 검색 수정 및 시퀄라이즈 셋팅 수정

### DIFF
--- a/src/controllers/road/road.search.controller.js
+++ b/src/controllers/road/road.search.controller.js
@@ -1,4 +1,4 @@
-import roadSearchService from "../../services/road/road.search.service.js";
+import {roadSearchService} from "../../services/road/road.search.service.js";
 import { InvalidInputError } from "../../utils/errors/errors.js";
 import { OkSuccess } from "../../utils/success/success.js";
 

--- a/src/dtos/road/road.search.dto.js
+++ b/src/dtos/road/road.search.dto.js
@@ -1,14 +1,13 @@
 export class RoadSearchDto {
-  constructor({ route_id, name, description, routeImgs, dataValues }) {
-    this.routeId = route_id;
+  constructor({ routeId, name, description, like_count, review_count, thumbnail_url }) {
+    this.routeId = routeId;
     this.name = name;
     this.description = description;
-    this.thumbnail_url = routeImgs?.[0]?.routeImgUrl || null;
-    this.review_count = Number(dataValues?.review_count) || 0;
-    this.like_count = Number(dataValues?.like_count) || 0;
+    this.like_count = like_count;
+    this.review_count = review_count;
+    this.thumbnail_url = thumbnail_url;
   }
 }
-
 
 export class RoadSearchResponseDto {
   constructor({ totalCount, page, size, roads }) {

--- a/src/models/database/init-models.js
+++ b/src/models/database/init-models.js
@@ -76,3 +76,4 @@ function initModels(sequelize) {
 module.exports = initModels;
 module.exports.initModels = initModels;
 module.exports.default = initModels;
+

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -12,9 +12,7 @@ const environmentConfig = config[env];
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const db = {};
 
-// Sequelize 인스턴스 생성
 const sequelize = new Sequelize(
   environmentConfig.database,
   environmentConfig.username,
@@ -24,17 +22,17 @@ const sequelize = new Sequelize(
     dialect: environmentConfig.dialect,
     port: environmentConfig.port,
     timezone: environmentConfig.timezone,
-    logging: console.log,
+    logging: false, //로그 출력 안되게 바꿈 (너무 길어서서) 
   }
 );
 
-// 모델 파일 순서 수동으로 지정
+// 모델 파일 순서 지정
 const modelFiles = [
   "users.js",
   "socialLogins.js",
   "places.js",
-  "placeImgs.js",       // ✅ 추가
-  "placeRoutes.js",     // ✅ 추가
+  "placeImgs.js",
+  "placeRoutes.js",
   "routes.js",
   "reviews.js",
   "routeBookmarks.js",
@@ -44,26 +42,26 @@ const modelFiles = [
   "jwtToken.js",
 ];
 
-// 각 모델을 순차적으로 불러와서 db 객체에 추가
-modelFiles.forEach((file) => {
+const db = {};
+
+// 비동기 초기화 수행
+for (const file of modelFiles) {
   const modelPath = pathToFileURL(path.join(__dirname, "database", file)).href;
+  const modelModule = await import(modelPath);
+  const modelInstance = modelModule.default(sequelize, Sequelize.DataTypes);
+  db[modelInstance.name] = modelInstance;
+  console.log(`✅ Model loaded: ${file}`);
+}
 
-  import(modelPath).then((model) => {
-    const modelInstance = model.default(sequelize, Sequelize.DataTypes);
-    console.log(`Model loaded: ${file}`);
-    db[modelInstance.name] = modelInstance;
-  });
-});
-
-// 모델 간 관계 설정 (모든 모델이 로드된 후에 설정)
+// 모든 모델 로드된 뒤 관계 설정
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
   }
 });
-// Sequelize 인스턴스와 등록된 모델 export
+
+// Sequelize와 함께 export
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
-
 
 export default db;

--- a/src/repositories/road/road.search.repository.js
+++ b/src/repositories/road/road.search.repository.js
@@ -1,17 +1,61 @@
 import db from "../../models/index.js";
-//console.log("🔍 모델 키:", Object.keys(db));
-//console.log("🔍 Routes.associations:", Object.keys(db.routes?.associations || {}));
+import { Op, fn, col, literal } from "sequelize";
 
-// 루트 키워드로 검색하기
+//루트 키워드로 검색하기 
 export const findRoadByKeyword = async (keyword, offset = 0, limit = 6) => {
   return await db.Routes.findAndCountAll({
     where: {
-      [db.Sequelize.Op.or]: [
-        { name: { [db.Sequelize.Op.like]: `%${keyword}%` } },
-        { description: { [db.Sequelize.Op.like]: `%${keyword}%` } }
+      [Op.or]: [
+        { name: { [Op.like]: `%${keyword}%` } },
+        { description: { [Op.like]: `%${keyword}%` } }
       ]
     },
+    attributes: [
+      ['route_id', 'routeId'],
+      'name',
+      'description',
+      [fn("COUNT", literal("DISTINCT RouteLikes.like_id")), "like_count"],
+      [fn("COUNT", literal("DISTINCT Reviews.review_id")), "review_count"]
+    ],
+    include: [
+      {
+        model: db.RouteImgs,
+        as: "RouteImgs",
+        attributes: ["route_img_url"],
+        limit: 1
+      },
+      {
+        model: db.RouteLikes,
+        as: "RouteLikes",
+        attributes: [],
+        where: { is_liked: true },
+        required: false
+      },
+      {
+        model: db.Reviews,
+        as: "Reviews",
+        attributes: [],
+        required: false
+      }
+    ],
+    group: ["Routes.route_id"],
     offset,
     limit,
+    subQuery: false
   });
+};
+
+// 썸네일 조회 함수 추가하기 
+export const getThumbnailByRouteId = async (routeId) => {
+  if (!routeId) {
+    console.warn("❗ invalid routeId passed to getThumbnailByRouteId:", routeId);
+    return null;
+  }
+
+  const thumbnail = await db.RouteImgs.findOne({
+    where: { route_id: routeId },
+    attributes: ["route_img_url"]
+  });
+
+  return thumbnail?.get("route_img_url") || null;
 };

--- a/src/routes/road/road.routes.js
+++ b/src/routes/road/road.routes.js
@@ -16,7 +16,7 @@ router.post("/:routeId/reviews", authenticateJWT, roadController.newReview);
 router.get("/:routeId/reviews", authenticateJWT, roadController.listReview);
 
 // 루트 검색 페이징 
-router.get("/search",roadSearch);
+router.get("/search",authenticateJWT, roadSearch);
 
 //루트 sns 링크 생성 
 router.post("/:routeId/share", authenticateJWT, createShareLink);

--- a/src/services/road/road.search.service.js
+++ b/src/services/road/road.search.service.js
@@ -1,20 +1,42 @@
+import {
+  findRoadByKeyword,
+  getThumbnailByRouteId
+} from "../../repositories/road/road.search.repository.js";
 import { RoadSearchDto, RoadSearchResponseDto } from "../../dtos/road/road.search.dto.js";
-import { findRoadByKeyword } from "../../repositories/road/road.search.repository.js";
 
-const roadSearchService = {
+export const roadSearchService = {
   searchByKeyword: async (query, page = 1, size = 6) => {
     const offset = (page - 1) * size;
+
     const { rows, count } = await findRoadByKeyword(query, offset, size);
 
-    const roads = rows.map(route => new RoadSearchDto(route));
+    // 각 루트마다 썸네일을 별도 쿼리로 가져옴
+    const roads = [];
+
+    for (const row of rows) {
+       const routeId = row.get("routeId") ?? row.route_id; // 안전하게 fall-back
+
+      //console.log("routeId:", routeId); 
+      
+      const thumbnail_url = await getThumbnailByRouteId(row.get("routeId"));
+      //console.log("routeId:", routeId);
+      //console.log("썸네일 URL:", thumbnail_url);
+
+      roads.push(new RoadSearchDto({
+        routeId: row.get("routeId"),
+        name: row.name,
+        description: row.description,
+        like_count: Number(row.get("like_count") || 0),
+        review_count: Number(row.get("review_count") || 0),
+        thumbnail_url
+      }));
+    }
 
     return new RoadSearchResponseDto({
-      totalCount: typeof count === 'number' ? count : count.length,
+      totalCount: Array.isArray(count) ? count.length : count,
       page,
       size,
-      roads,
+      roads
     });
   }
 };
-
-export default roadSearchService;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54 

## 📝작업 내용

> 

**1. 루트 검색 기능 수정 (GET /api/road/search)**
검색 결과에 다음 정보 포함되도록 처리:

- routeId, name, description
- like_count: 해당 루트의 좋아요 수
- review_count: 리뷰 수
- thumbnail_url: 대표 이미지 URL (없을 경우 null)


**2. 썸네일 이미지 별도 조회 처리**

- hasMany + limit 조합의 eager loading 제약을 피하기 위해 썸네일 이미지는 RouteImgs.findOne()으로 별도 쿼리 수행
- DTO에 대표 썸네일 URL 주입
- 쿼리 최적화를 위해 이후 Promise.all() 등으로 병렬 처리 가능

**3. 모델 로딩 방식 리팩토링 (models/index.js)**

- 기존의 fs.readdirSync() + 비동기 import 방식 → 순차 로딩 방식으로 수정
- modelFiles 배열에 모델 정의 순서를 명시적으로 선언
- 각 모델을 await import(...) 후 sequelize.define() → db[model.name]에 저장
- 모든 모델이 등록된 이후에 관계 설정(associate())을 수행하도록 변경



### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/03c70f7d-5801-4527-8d3c-cd40c2106a03)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
